### PR TITLE
added task to configure Git's safe directory

### DIFF
--- a/control-flow.yaml
+++ b/control-flow.yaml
@@ -81,6 +81,11 @@
       state: absent
     when: ansible_distribution == "Ubuntu"
     become: yes
+    
+  - name: Configure Git safe directory
+    shell: git config --global --add safe.directory {{ website_dir }}
+    when: ansible_distribution == "Ubuntu"
+    become: yes
 
   - name: Clone website on Ubuntu servers 
     git:


### PR DESCRIPTION
In the step "clone website on Ubuntu servers", there's an error message indicating that a Git security feature is preventing the operation because of "dubious ownership" in the repository directory. 
Adding this configuration step fixes that

<img width="895" alt="Screenshot 2025-03-13 at 11 03 14" src="https://github.com/user-attachments/assets/d239abb2-a920-42a8-8774-a78a85d62e8d" />

cc: @akinwunmi-akinrimisi 